### PR TITLE
feat : CreatCart

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="C:\gradle-8.3" />
+        <option name="gradleJvm" value="17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/src/main/java/sparta/m6nytooneproject/cart/controller/CartController.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/controller/CartController.java
@@ -1,9 +1,17 @@
 package sparta.m6nytooneproject.cart.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sparta.m6nytooneproject.cart.dto.CartRequestDto;
+import sparta.m6nytooneproject.cart.dto.CartResponseDto;
+import sparta.m6nytooneproject.cart.entity.Cart;
 import sparta.m6nytooneproject.cart.repository.CartRepository;
 
 @RestController
@@ -13,4 +21,17 @@ import sparta.m6nytooneproject.cart.repository.CartRepository;
 public class CartController {
 
     private final CartRepository cartRepository;
+
+    @PostMapping
+    public ResponseEntity<CartResponseDto> createCart(@Valid @RequestBody CartRequestDto request) {
+        CartResponseDto response = cartService.addCart(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+    /*
+    전체조회시 s추가 : getAll(도메인명)
+
+    단건조회시 : getOne(도메인명)
+
+    수정 : update(도메인명)
+    */
 }

--- a/src/main/java/sparta/m6nytooneproject/cart/controller/CartController.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/controller/CartController.java
@@ -13,6 +13,7 @@ import sparta.m6nytooneproject.cart.dto.CartRequestDto;
 import sparta.m6nytooneproject.cart.dto.CartResponseDto;
 import sparta.m6nytooneproject.cart.entity.Cart;
 import sparta.m6nytooneproject.cart.repository.CartRepository;
+import sparta.m6nytooneproject.cart.service.CartService;
 
 @RestController
 @RequestMapping("/carts")//공통경로
@@ -20,11 +21,11 @@ import sparta.m6nytooneproject.cart.repository.CartRepository;
 @Validated
 public class CartController {
 
-    private final CartRepository cartRepository;
+    private final CartService cartService;
 
     @PostMapping
     public ResponseEntity<CartResponseDto> createCart(@Valid @RequestBody CartRequestDto request) {
-        CartResponseDto response = cartService.addCart(request);
+        CartResponseDto response = cartService.createCart(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
     /*

--- a/src/main/java/sparta/m6nytooneproject/cart/dto/CartRequestDto.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/dto/CartRequestDto.java
@@ -1,4 +1,30 @@
 package sparta.m6nytooneproject.cart.dto;
 
+import lombok.Getter;
+import sparta.m6nytooneproject.product.entity.Product;
+import sparta.m6nytooneproject.user.entity.User;
+
+
+@Getter
 public class CartRequestDto {
+
+    private Long id;
+    private int quantity;
+    private Long userId;
+    private Long productId;
+
+    public CartRequestDto(Long id, int quantity, Long userId, Long productId) {
+        this.id = id;
+        this.quantity = quantity;
+        this.userId = userId;
+        this.productId = productId;
+    }
+
+    public Long getUserId(Long userId) {
+        return userId = userId;
+    }
+
+    public Long getProductId(Long productId) {
+        return productId =  productId;
+    }
 }

--- a/src/main/java/sparta/m6nytooneproject/cart/dto/CartRequestDto.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/dto/CartRequestDto.java
@@ -13,18 +13,4 @@ public class CartRequestDto {
     private Long userId;
     private Long productId;
 
-    public CartRequestDto(Long id, int quantity, Long userId, Long productId) {
-        this.id = id;
-        this.quantity = quantity;
-        this.userId = userId;
-        this.productId = productId;
-    }
-
-    public Long getUserId(Long userId) {
-        return userId = userId;
-    }
-
-    public Long getProductId(Long productId) {
-        return productId =  productId;
-    }
 }

--- a/src/main/java/sparta/m6nytooneproject/cart/dto/CartResponseDto.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/dto/CartResponseDto.java
@@ -1,5 +1,6 @@
 package sparta.m6nytooneproject.cart.dto;
 
+import sparta.m6nytooneproject.cart.entity.Cart;
 import sparta.m6nytooneproject.product.entity.Product;
 import sparta.m6nytooneproject.user.entity.User;
 
@@ -7,19 +8,19 @@ import java.time.LocalDateTime;
 
 public class CartResponseDto {
 
-    private Long id;
-    private int quantity;
-    private Long userId;
-    private Long productId;
-    private LocalDateTime createdDate;
-    private LocalDateTime updatedDate;
+    final private Long id;
+    final private int quantity;
+    final private Long userId;
+    final private Long productId;
+    final private LocalDateTime createdAt;
+    final private LocalDateTime updatedAt;
 
-    public CartResponseDto(Long id, int quantity, Long userId, Long productId, LocalDateTime createdDate, LocalDateTime updatedDate) {
-        this.id = id;
-        this.quantity = quantity;
-        this.userId = userId;
-        this.productId = productId;
-        this.createdDate = createdDate;
-        this.updatedDate = updatedDate;
+    public CartResponseDto(Cart cart) {
+        this.id = cart.getId();
+        this.quantity = cart.getQuantity();
+        this.userId = cart.getUser().getId();
+        this.productId = cart.getProduct().getId();
+        this.createdAt = cart.getCreatedAt();
+        this.updatedAt = cart.getModifiedAt();
     }
 }

--- a/src/main/java/sparta/m6nytooneproject/cart/dto/CartResponseDto.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/dto/CartResponseDto.java
@@ -1,4 +1,25 @@
 package sparta.m6nytooneproject.cart.dto;
 
+import sparta.m6nytooneproject.product.entity.Product;
+import sparta.m6nytooneproject.user.entity.User;
+
+import java.time.LocalDateTime;
+
 public class CartResponseDto {
+
+    private Long id;
+    private int quantity;
+    private Long userId;
+    private Long productId;
+    private LocalDateTime createdDate;
+    private LocalDateTime updatedDate;
+
+    public CartResponseDto(Long id, int quantity, Long userId, Long productId, LocalDateTime createdDate, LocalDateTime updatedDate) {
+        this.id = id;
+        this.quantity = quantity;
+        this.userId = userId;
+        this.productId = productId;
+        this.createdDate = createdDate;
+        this.updatedDate = updatedDate;
+    }
 }

--- a/src/main/java/sparta/m6nytooneproject/cart/entity/Cart.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/entity/Cart.java
@@ -2,9 +2,7 @@ package sparta.m6nytooneproject.cart.entity;
 
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import sparta.m6nytooneproject.global.entity.BaseEntity;
@@ -14,6 +12,8 @@ import sparta.m6nytooneproject.user.entity.User;
 @Getter
 @Entity
 @Table(name = "carts")
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Cart extends BaseEntity {
 
@@ -27,19 +27,23 @@ public class Cart extends BaseEntity {
     // 유저매핑
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
-//    상품 매핑
+    //상품 매핑
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private Product product;
 
-//    생성자
-    public Cart(Long id, User user, Product product) {
+    //생성자
+    public Cart(Long id, int quantity, User user, Product product) {
         this.id = id;
+        this.quantity = quantity;
         this.user = user;
         this.product = product;
+    }
+
+    public void updateQuantity(int newQuantity) {
+        // 필요 시 여기서 재고 수량과 비교하는 로직을 추가할 수 있습니다.
+        this.quantity = newQuantity;
     }
 }

--- a/src/main/java/sparta/m6nytooneproject/cart/entity/Cart.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/entity/Cart.java
@@ -12,8 +12,6 @@ import sparta.m6nytooneproject.user.entity.User;
 @Getter
 @Entity
 @Table(name = "carts")
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Cart extends BaseEntity {
 

--- a/src/main/java/sparta/m6nytooneproject/cart/repository/CartRepository.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/repository/CartRepository.java
@@ -2,8 +2,14 @@ package sparta.m6nytooneproject.cart.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import sparta.m6nytooneproject.cart.entity.Cart;
+import sparta.m6nytooneproject.product.entity.Product;
+import sparta.m6nytooneproject.user.entity.User;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
+    Optional<Cart> findByUserAndProduct(User user, Product product);
 
 }

--- a/src/main/java/sparta/m6nytooneproject/cart/service/CartService.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/service/CartService.java
@@ -1,12 +1,75 @@
 package sparta.m6nytooneproject.cart.service;
 
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestBody;
+import sparta.m6nytooneproject.cart.dto.CartRequestDto;
+import sparta.m6nytooneproject.cart.dto.CartResponseDto;
+import sparta.m6nytooneproject.cart.entity.Cart;
 import sparta.m6nytooneproject.cart.repository.CartRepository;
+import sparta.m6nytooneproject.product.entity.Product;
+import sparta.m6nytooneproject.product.repository.ProductRepository;
+import sparta.m6nytooneproject.user.dto.UserResponseDto;
+import sparta.m6nytooneproject.user.entity.User;
+import sparta.m6nytooneproject.user.repository.UserRepository;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CartService {
 
     private final CartRepository cartRepository;
+    private final UserRepository userRepository; // 고객 확인용
+    private final ProductRepository productRepository; //상품 확인용
+
+
+    public CartResponseDto createCart(@Valid @RequestBody CartRequestDto request) {
+
+        // 1. 고객 존재 여부 확인
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 고객입니다."));
+
+        // 2. 존재하는 상품인지 확인
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 상품입니다."));
+
+        // 3. 판매 중인 상품인지 확인 (품절, 단종 체크)
+        Status ProductStatus = product.getStatus();//존재하는 상품의 상태 확인
+        if (!product.getStatus().equals(ProductStatus.ON_SALE)) {//상품상태 enum으로 생성되었는지 확인
+            throw new IllegalStateException("현재 판매 중인 상품이 아닙니다. (상태: " + product.getStatus() + ")");
+        }
+
+        // 4. 기존 장바구니에 동일 상품이 있는지 확인
+        Optional<Cart> existingCart = cartRepository.findByUserAndProduct(user, product);
+
+        Cart cart;
+        if (existingCart.isPresent()) {
+            // 4-1. 동일 상품이 있으면 수량만 증가
+            cart = existingCart.get();
+            cart.updateQuantity(cart.getQuantity() + request.getQuantity());
+        } else {
+            // 5. 다른 상품인 경우 새로운 장바구니 생성
+            cart = new Cart(request.getId(), request.getQuantity(), user, product);
+            cart = cartRepository.save(cart);
+
+        }
+
+        return new CartResponseDto(
+                cart.getId(),
+                cart.getQuantity(),
+                cart.getUser().getId(),
+                cart.getProduct().getId(),
+                cart.getCreatedAt(),
+                cart.getModifiedAt()
+        );
+    }
+    }
+
+
+
 }

--- a/src/main/java/sparta/m6nytooneproject/cart/service/CartService.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/service/CartService.java
@@ -52,21 +52,14 @@ public class CartService {
             // 4-1. 동일 상품이 있으면 수량만 증가
             cart = existingCart.get();
             cart.updateQuantity(cart.getQuantity() + request.getQuantity());
-        } else {
+        }
             // 5. 다른 상품인 경우 새로운 장바구니 생성
             cart = new Cart(request.getId(), request.getQuantity(), user, product);
-            cart = cartRepository.save(cart);
+        Cart savedCart = cartRepository.save(cart);
 
-        }
 
-        return new CartResponseDto(
-                cart.getId(),
-                cart.getQuantity(),
-                cart.getUser().getId(),
-                cart.getProduct().getId(),
-                cart.getCreatedAt(),
-                cart.getModifiedAt()
-        );
+
+        return new CartResponseDto(savedCart);
     }
     }
 


### PR DESCRIPTION
장바구니 생성전 고객과 상품존재여부 및 상품 상태 확인, 기존 장바구니 상품존재여부 체크후 장바구니 생성

## 개요
- Cart생성시 고객id와 상품id를 통해 존재여부 및 상품 상태 체크후  Cart생성

## 변경 사항
- creatCart API 구현

## 테스트 방법
.

## 관련 이슈
- 이 PR과 관련된 이슈 번호를 작성해주세요. (e.g., `#123`)
  - Resolves #9 

## 추가 설명
- 고객과 상품 존재여부는 각각의 id로 확인
