### PR TITLE
HotFix : user controller method url 중복 수정

### DIFF
--- a/src/main/java/sparta/m6nytooneproject/user/controller/UserController.java
+++ b/src/main/java/sparta/m6nytooneproject/user/controller/UserController.java
@@ -3,7 +3,6 @@ package sparta.m6nytooneproject.user.controller;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.sql.Update;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -98,7 +97,7 @@ public class UserController {
     }
 
     // 슈퍼관리자가 등록된 관리자들 정보 수정 (업데이트) - 이름, 이메일, 전화번호 수정 가능
-    @PatchMapping("/registered/{userId}")
+    @PatchMapping("/registered/{userId}/info")
     public ResponseEntity<ApiResponseDto<UpdateUserInfoResponseDto>> updateUserInfo(
             @PathVariable Long userId,
             @Valid @RequestBody UpdateUserInfoRequestDto request
@@ -107,7 +106,7 @@ public class UserController {
     }
 
     // 슈퍼 관리자가 다른 관리자의 역할 변경 (업데이트)
-    @PatchMapping("/registered/{userId}")
+    @PatchMapping("/registered/{userId}/status")
     public ResponseEntity<ApiResponseDto<UpdateRegisteredUserResponseDto>> updateRegisteredUser(
             @PathVariable Long userId,
             @Valid @RequestBody UpdateRegisteredRequestDto request


### PR DESCRIPTION
## 개요
-  user controller method url 중복 수정

## 변경 사항
- 기존 /registered/{userId}으로 동일하게 매핑되어있던 URL 정보 수정
## 테스트 방법
- 

## 관련 이슈
- 

## 추가 설명
- method(GET,PATCH,POST) 가 같다면 /registered/{userId} 같은 동일한 URL을 사용하면 중복된 API로 인식하여 에러가 발생합니다.

/registered/{userId}
/registered/{orderId}

-> 이런 구조도 같은 에러 발생!!
