### PR TITLE
refactor : 주문 페이지 조회 고객, 관리자 분리.

### DIFF
--- a/src/main/java/sparta/m6nytooneproject/order/controller/OrderController.java
+++ b/src/main/java/sparta/m6nytooneproject/order/controller/OrderController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import sparta.m6nytooneproject.global.dto.ApiResponseDto;
 import sparta.m6nytooneproject.order.dto.*;
 import sparta.m6nytooneproject.order.entity.OrderSort;
+import sparta.m6nytooneproject.order.entity.OrderStatus;
 import sparta.m6nytooneproject.order.service.OrderService;
 import sparta.m6nytooneproject.security.CustomUserDetails;
 
@@ -46,20 +47,35 @@ public class OrderController {
         );
     }
 
-    @GetMapping
+    @GetMapping("/lists")
+    @PreAuthorize("hasAnyRole('SUPER','OPER','MARKET','CS')")
     public ApiResponseDto<OrderListResponseDto> getAllOrders(
             @RequestParam(required = false) String username,
+            @RequestParam(required = false , defaultValue = "1") int page,
+            @RequestParam(required = false, defaultValue = "10") int size,
+            @RequestParam(required = false) OrderStatus status,
+            @RequestParam(required = false, defaultValue = "CREATED_AT")  OrderSort orderSort
+    ) {
+        return ApiResponseDto.pagination(HttpStatus.OK,
+                orderService.getAllOrders(page, size, orderSort, username, status),
+                "정상적으로 조회 되었습니다"
+        );
+    }
+
+    @GetMapping("/list/customers")
+    public ApiResponseDto<OrderListResponseDto> getAllOrdersByCustomer(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(required = false , defaultValue = "1") int page,
             @RequestParam(required = false, defaultValue = "10") int size,
             @RequestParam(required = false, defaultValue = "CREATED_AT")  OrderSort orderSort
     ) {
         return ApiResponseDto.pagination(HttpStatus.OK,
-                orderService.getAllOrders(page, size,orderSort, username),
+                orderService.getOrdersByCustomerId(page, size,orderSort, userDetails.getId()),
                 "정상적으로 조회 되었습니다"
         );
     }
 
-    @GetMapping("{orderId}")
+    @GetMapping("/{orderId}")
     @PreAuthorize("hasAnyRole('SUPER','OPER','MARKET','CS') or @orderSecurity.isOwner(authentication , #orderId)")
     public ApiResponseDto<OrderDetailResponseDto> getOneOrder(
             @PathVariable Long orderId
@@ -72,8 +88,7 @@ public class OrderController {
     @PatchMapping("/{orderId}/complete")
     @PreAuthorize("hasAnyRole('SUPER','OPER','MARKET','CS')")
     public ApiResponseDto<OrderDetailResponseDto> completeOrder(
-            @PathVariable Long orderId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @PathVariable Long orderId
     ) {
         return ApiResponseDto.success(HttpStatus.OK,
                 orderService.completeOrder(orderId)

--- a/src/main/java/sparta/m6nytooneproject/order/dto/OrderRequestByCustomerDto.java
+++ b/src/main/java/sparta/m6nytooneproject/order/dto/OrderRequestByCustomerDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 public class OrderRequestByCustomerDto {
-    @Min(value = 0 , message = "수량은 0개 이상 이어야 합니다.")
+    @Min(value = 1 , message = "수량은 1개 이상 이어야 합니다.")
     private Integer quantity;
     @Min(1)
     private Long productId;

--- a/src/main/java/sparta/m6nytooneproject/order/repository/OrderRepository.java
+++ b/src/main/java/sparta/m6nytooneproject/order/repository/OrderRepository.java
@@ -18,9 +18,19 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
         SELECT o
         FROM Order o
         WHERE (:userName IS NULL OR :userName = '' OR o.userName = :userName)
+          AND (:orderStatus IS NULL OR o.status = :orderStatus)
     """)
-    Page<Order> search(@Param("userName") String userName,
-                       Pageable pageable);
+    Page<Order> searchByName(
+            @Param("orderStatus") OrderStatus orderStatus,
+            @Param("userName") String userName,
+                             Pageable pageable);
+
+    @Query("""
+    SELECT o
+    FROM Order o
+    WHERE (:customerId IS NOT NULL AND o.customer.id = :customerId)
+    """)
+    Page<Order> searchByCustomerId(@Param("customerId") Long customerId, Pageable pageable);
 
     // 고객 리스트 조회 데이터 확장 (총 주문 수, 총 구매 금액)
     @Query("""

--- a/src/main/java/sparta/m6nytooneproject/order/service/OrderSecurityExpression.java
+++ b/src/main/java/sparta/m6nytooneproject/order/service/OrderSecurityExpression.java
@@ -11,7 +11,6 @@ import sparta.m6nytooneproject.security.CustomUserDetails;
 public class OrderSecurityExpression {
 
     private final OrderRepository orderRepository;
-
     public boolean isOwner(Authentication authentication, Long orderId) {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 

--- a/src/main/java/sparta/m6nytooneproject/order/service/OrderService.java
+++ b/src/main/java/sparta/m6nytooneproject/order/service/OrderService.java
@@ -14,6 +14,7 @@ import sparta.m6nytooneproject.global.exception.order.CancelOrderException;
 import sparta.m6nytooneproject.global.exception.order.InvalidOrderStatusException;
 import sparta.m6nytooneproject.global.exception.order.OrderException;
 import sparta.m6nytooneproject.global.exception.order.OrderNotFoundException;
+import sparta.m6nytooneproject.global.exception.user.UserRoleNotMatchException;
 import sparta.m6nytooneproject.order.dto.OrderDetailResponseDto;
 import sparta.m6nytooneproject.order.dto.OrderListResponseDto;
 import sparta.m6nytooneproject.order.dto.OrderRequestByCsDto;
@@ -63,6 +64,9 @@ public class OrderService {
     @Transactional
     public OrderDetailResponseDto createOrderByAdmin(OrderRequestByCsDto request, Long customerId , Long adminId) {
         User customer = userService.getUserById(customerId);
+        if(!customer.getRole().equals(UserRole.CUSTOMER)) {
+            throw new UserRoleNotMatchException("주문 대상이 고객이 아닙니다.");
+        }
         User admin = userService.getUserById(adminId);
         Product validProduct = productService.checkProductStock(request.getProductId() , request.getQuantity());
 
@@ -110,10 +114,17 @@ public class OrderService {
         return OrderDetailResponseDto.from(order);
     }
 
-    public Page<OrderListResponseDto> getAllOrders(int page, int size, OrderSort orderSort, String username) {
+    public Page<OrderListResponseDto> getAllOrders(int page, int size, OrderSort orderSort, String username, OrderStatus orderStatus) {
         Pageable pageable = PageRequest.of(page + AuthConstants.PAGE_DEFAULT, size, Sort.by(orderSort.getProperty()).descending());
 
-        Page<Order> orders = orderRepository.search(username, pageable);
+        Page<Order> orders = orderRepository.searchByName(orderStatus, username, pageable);
+        return orders.map(OrderListResponseDto::from);
+    }
+
+    public Page<OrderListResponseDto> getOrdersByCustomerId(int page, int size, OrderSort orderSort, Long customerId) {
+        Pageable pageable = PageRequest.of(page + AuthConstants.PAGE_DEFAULT, size, Sort.by(orderSort.getProperty()).descending());
+
+        Page<Order> orders = orderRepository.searchByCustomerId(customerId, pageable);
         return orders.map(OrderListResponseDto::from);
     }
 


### PR DESCRIPTION
## 개요
- refactor : 주문 페이지 조회 고객, 관리자 분리.

## 변경 사항
- 관리자 조회시 상태, 이름으로 조회 추가
- 회원은 로그인한 회원의 주문 정보만 조회 할 수 있도록 수정
- cs 주문시 주문 대상이 관리자인경우 UserRoleNotMatchException 에러 발생