### PR TITLE
refactor : Cart생성 및 수정시 상품재고초과 에러 추가 및 요청body수정

### DIFF
--- a/src/main/java/sparta/m6nytooneproject/cart/controller/CartController.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/controller/CartController.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import sparta.m6nytooneproject.cart.dto.CartRequestDto;
 import sparta.m6nytooneproject.cart.dto.CartResponseDto;
+import sparta.m6nytooneproject.cart.dto.CartUpdateRequestDto;
 import sparta.m6nytooneproject.cart.entity.Cart;
 import sparta.m6nytooneproject.cart.service.CartService;
 import sparta.m6nytooneproject.global.dto.ApiResponseDto;
@@ -61,7 +62,7 @@ public class CartController {
     @PreAuthorize("hasAnyRole('SUPER','OPER','MARKET','CS') or @cartSecurity.isSelf(authentication , #cartId)")
     public ApiResponseDto<CartResponseDto> updateCart(
             @PathVariable Long cartId,
-            @Valid @RequestBody CartRequestDto request,
+            @Valid @RequestBody CartUpdateRequestDto request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         CartResponseDto result = cartService.updateCart(cartId, request, userDetails.getId());

--- a/src/main/java/sparta/m6nytooneproject/cart/dto/CartUpdateRequestDto.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/dto/CartUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package sparta.m6nytooneproject.cart.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+
+@Getter
+public class CartUpdateRequestDto {
+
+    @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
+    private int quantity;
+
+}

--- a/src/main/java/sparta/m6nytooneproject/cart/service/CartService.java
+++ b/src/main/java/sparta/m6nytooneproject/cart/service/CartService.java
@@ -11,10 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestBody;
 import sparta.m6nytooneproject.cart.dto.CartRequestDto;
 import sparta.m6nytooneproject.cart.dto.CartResponseDto;
+import sparta.m6nytooneproject.cart.dto.CartUpdateRequestDto;
 import sparta.m6nytooneproject.cart.entity.Cart;
 import sparta.m6nytooneproject.cart.repository.CartRepository;
 import sparta.m6nytooneproject.global.AuthConstants;
 import sparta.m6nytooneproject.global.exception.cart.CartNotFoundException;
+import sparta.m6nytooneproject.global.exception.cart.OutOfStockException;
 import sparta.m6nytooneproject.global.exception.common.SessionNotActiveException;
 import sparta.m6nytooneproject.global.exception.common.UnAuthorizedException;
 import sparta.m6nytooneproject.global.exception.product.ProductNotOnSaleException;
@@ -53,10 +55,21 @@ public class CartService {
         }
         // 3. 기존 장바구니에 동일 상품이 있는지 확인
         Optional<Cart> existingCart = cartRepository.findByUserAndProduct(user, product);
+
+        //상품 재고 체크 : 기존 장바구니에 해당 상품이 있는지 확인하고, 있으면 수량을 가져오고 없으면 0을 반환
+        int currentCartQuantity = existingCart.map(Cart::getQuantity).orElse(0);
+        //기존 수량에 사용자가 새로 추가하려는 수량을 더하여 총수량 생성
+        int totalRequestedQuantity = currentCartQuantity + request.getQuantity();
+
+        //총수량과 상품재고 비교
+        if (totalRequestedQuantity > product.getStock()) {
+            throw new OutOfStockException("상품의 재고가 부족합니다. (현재 재고: " + product.getStock() + "개)");
+        }
+
         // 3-1. 동일 상품이 있으면 수량만 증가
         if(existingCart.isPresent()){
             Cart cart = existingCart.get();
-            cart.updateQuantity(cart.getQuantity() + request.getQuantity());
+            cart.updateQuantity(totalRequestedQuantity);
             return new CartResponseDto(cart);
         }else {
             // 4. 다른 상품인 경우 새로운 장바구니 생성
@@ -84,13 +97,21 @@ public class CartService {
         Cart cart = getCartById(cartId);
         return new CartResponseDto(cart);
     }
+
     @Transactional
     //카트id로 수정(로그인한 본인이 만든 카트인지확인필요)
-    public CartResponseDto updateCart(Long cartId, CartRequestDto request, Long loginUserId) {
+    public CartResponseDto updateCart(Long cartId, CartUpdateRequestDto request, Long loginUserId) {
+
         //해당id의 카트가 존재하는지 확인
         Cart cart = getCartById(cartId);
         //요청한 카트를 만든 유저id와 로그인한 유저id비교
         checkUserAuth(cart, loginUserId);
+
+        // 수정하려는 수량이 상품의 전체 재고를 초과하는지 체크
+        if (request.getQuantity() > cart.getProduct().getStock()) {
+            throw new OutOfStockException("상품의 재고가 부족합니다. (현재 재고: " + cart.getProduct().getStock() + "개)");
+        }
+
         cart.updateQuantity(request.getQuantity());
         return new CartResponseDto(cart);
     }

--- a/src/main/java/sparta/m6nytooneproject/global/exception/cart/OutOfStockException.java
+++ b/src/main/java/sparta/m6nytooneproject/global/exception/cart/OutOfStockException.java
@@ -1,0 +1,11 @@
+package sparta.m6nytooneproject.global.exception.cart;
+
+import org.springframework.http.HttpStatus;
+import sparta.m6nytooneproject.global.exception.common.ServiceException;
+
+public class OutOfStockException extends ServiceException {
+    public OutOfStockException(String message) {
+
+        super(HttpStatus.BAD_REQUEST, message);
+    }
+}


### PR DESCRIPTION
## 개요
- Cart생성 및 수정시 상품재고초과 에러 추가 및 요청body수정

## 변경 사항
장바구니 생성시 상품재고 초과하여 생성하거나 수정시 에러처리, 장바구니 수정Dto추가

## 테스트 방법
- 장바구니 수정시 상품id 없어도됨
- 장바구니 생성과 수정시 상품재고보다 초과되지않게 수정